### PR TITLE
localize core UI labels

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -12,6 +12,7 @@ import Logo from '~/components/Logo';
 import Menu from '~/components/Menu';
 import { AuthSession } from '~/server/web/sessions';
 import cn from '~/utils/cn';
+import { t } from '~/utils/i18n';
 
 interface Props {
 	configAvailable: boolean;
@@ -95,7 +96,10 @@ export default function Header(data: Props) {
 					<h1 className="text-2xl font-semibold">headplane</h1>
 				</div>
 				<div className="flex items-center gap-x-4">
-					<Link href="https://tailscale.com/download" text="Download" />
+					<Link
+						href="https://tailscale.com/download"
+						text={t('header.download')}
+					/>
 					<Link href="https://github.com/tale/headplane" text="GitHub" />
 					<Link href="https://github.com/juanfont/headscale" text="Headscale" />
 					{data.user ? (
@@ -131,7 +135,9 @@ export default function Header(data: Props) {
 								<Menu.Section>
 									<Menu.Item key="profile" textValue="Profile">
 										<div className="text-black dark:text-headplane-50">
-											<p className="font-bold">{data.user.name || data.user.displayName}</p>
+											<p className="font-bold">
+												{data.user.name || data.user.displayName}
+											</p>
 											<p>{data.user.email}</p>
 										</div>
 									</Menu.Item>
@@ -149,14 +155,14 @@ export default function Header(data: Props) {
 					{data.access.machines ? (
 						<TabLink
 							to="/machines"
-							name="Machines"
+							name={t('header.nav.machines')}
 							icon={<Server className="w-5" />}
 						/>
 					) : undefined}
 					{data.access.users ? (
 						<TabLink
 							to="/users"
-							name="Users"
+							name={t('header.nav.users')}
 							icon={<Users className="w-5" />}
 						/>
 					) : undefined}

--- a/app/routes/machines/machine.tsx
+++ b/app/routes/machines/machine.tsx
@@ -14,6 +14,7 @@ import type { LoadContext } from '~/server';
 import type { Machine, User } from '~/types';
 import cn from '~/utils/cn';
 import { getOSInfo, getTSVersion } from '~/utils/host-info';
+import { t } from '~/utils/i18n';
 import { mapNodes } from '~/utils/node-info';
 import { mapTagsToComponents, uiTagsForNode } from './components/machine-row';
 import MenuOptions from './components/menu';
@@ -79,7 +80,7 @@ export default function Page() {
 		<div>
 			<p className="mb-8 text-md">
 				<RemixLink to="/machines" className="font-medium">
-					All Machines
+					{t('machines.all_machines')}
 				</RemixLink>
 				<span className="mx-2">/</span>
 				{node.givenName}
@@ -109,7 +110,10 @@ export default function Page() {
 					</span>
 					<div className="flex items-center gap-x-2.5 mt-1">
 						<UserCircle />
-						{node.user.name || node.user.displayName || node.user.email || node.user.id}
+						{node.user.name ||
+							node.user.displayName ||
+							node.user.email ||
+							node.user.id}
 					</div>
 				</div>
 				<div className="p-2 pl-4">
@@ -254,7 +258,15 @@ export default function Page() {
 				className="w-full max-w-full grid grid-cols-1 lg:grid-cols-2 gap-y-2 sm:gap-x-12"
 			>
 				<div className="flex flex-col gap-1">
-					<Attribute name="Creator" value={node.user.name || node.user.displayName || node.user.email || node.user.id} />
+					<Attribute
+						name="Creator"
+						value={
+							node.user.name ||
+							node.user.displayName ||
+							node.user.email ||
+							node.user.id
+						}
+					/>
 					<Attribute name="Machine name" value={node.givenName} />
 					<Attribute
 						tooltip="OS hostname is published by the machine’s operating system and is used as the default name for the machine."
@@ -324,14 +336,14 @@ export default function Page() {
 					/>
 					<Attribute
 						isCopyable
-						tooltip="Users of your tailnet can use this DNS short name to access this machine."
+						tooltip={t('machines.tooltip_short_domain')}
 						name="Short domain"
 						value={node.givenName}
 					/>
 					{magic ? (
 						<Attribute
 							isCopyable
-							tooltip="Users of your tailnet can use this DNS name to access this machine."
+							tooltip={t('machines.tooltip_full_domain')}
 							name="Full domain"
 							value={`${node.givenName}.${magic}`}
 						/>

--- a/app/routes/machines/overview.tsx
+++ b/app/routes/machines/overview.tsx
@@ -8,6 +8,7 @@ import type { LoadContext } from '~/server';
 import { Capabilities } from '~/server/web/roles';
 import type { Machine, User } from '~/types';
 import cn from '~/utils/cn';
+import { t } from '~/utils/i18n';
 import { mapNodes } from '~/utils/node-info';
 import MachineRow from './components/machine-row';
 import NewMachine from './dialogs/new';
@@ -86,7 +87,7 @@ export default function Page() {
 		<>
 			<div className="flex justify-between items-center mb-6">
 				<div className="flex flex-col w-2/3">
-					<h1 className="text-2xl font-medium mb-2">Machines</h1>
+					<h1 className="text-2xl font-medium mb-2">{t('machines.title')}</h1>
 					<p>
 						Manage the devices connected to your Tailnet.{' '}
 						<Link

--- a/app/routes/users/components/manage-banner.tsx
+++ b/app/routes/users/components/manage-banner.tsx
@@ -2,6 +2,7 @@ import { Building2, House, Key } from 'lucide-react';
 import Card from '~/components/Card';
 import Link from '~/components/Link';
 import type { HeadplaneConfig } from '~/server/config/schema';
+import { t } from '~/utils/i18n';
 import CreateUser from '../dialogs/create-user';
 
 interface ManageBannerProps {
@@ -25,12 +26,11 @@ export default function ManageBanner({ oidc, isDisabled }: ManageBannerProps) {
 					<p className="text-sm text-headplane-600 dark:text-headplane-300">
 						{oidc ? (
 							<>
-								Users are managed through your{' '}
+								{t('users.manage_banner.oidc_prefix')}
 								<Link to={oidc.issuer} name="OIDC Provider">
 									OpenID Connect provider
 								</Link>
-								{'. '}
-								Groups and user information do not automatically sync.{' '}
+								{t('users.manage_banner.oidc_suffix')}
 								<Link
 									to="https://headscale.net/stable/ref/oidc"
 									name="Headscale OIDC Documentation"
@@ -40,8 +40,7 @@ export default function ManageBanner({ oidc, isDisabled }: ManageBannerProps) {
 							</>
 						) : (
 							<>
-								Users are not managed externally. Using OpenID Connect can
-								create a better experience when using Headscale.{' '}
+								{t('users.manage_banner.not_managed')}
 								<Link
 									to="https://headscale.net/stable/ref/oidc"
 									name="Headscale OIDC Documentation"

--- a/app/routes/users/dialogs/delete-user.tsx
+++ b/app/routes/users/dialogs/delete-user.tsx
@@ -1,5 +1,6 @@
 import Dialog from '~/components/Dialog';
 import { Machine, User } from '~/types';
+import { t } from '~/utils/i18n';
 
 interface DeleteProps {
 	user: User & { machines: Machine[] };
@@ -18,8 +19,7 @@ export default function DeleteUser({ user, isOpen, setIsOpen }: DeleteProps) {
 				<Dialog.Title>Delete {name}?</Dialog.Title>
 				{user.machines.length > 0 ? (
 					<Dialog.Text className="mb-6">
-						Users cannot be deleted if they have machines. Please delete or
-						re-assign their machines to other users before proceeding.
+						{t('users.delete_has_machines')}
 					</Dialog.Text>
 				) : (
 					<Dialog.Text className="mb-6">

--- a/app/routes/users/onboarding.tsx
+++ b/app/routes/users/onboarding.tsx
@@ -18,6 +18,7 @@ import StatusCircle from '~/components/StatusCircle';
 import { LoadContext } from '~/server';
 import { Machine } from '~/types';
 import cn from '~/utils/cn';
+import { t } from '~/utils/i18n';
 import { useLiveData } from '~/utils/live-data';
 import log from '~/utils/log';
 import toast from '~/utils/toast';
@@ -139,7 +140,7 @@ export default function Page() {
 
 					<Options
 						defaultSelectedKey={osValue}
-						label="Download Selector"
+						label={t('onboarding.download_selector')}
 						className="my-4"
 					>
 						<Options.Item
@@ -184,12 +185,12 @@ export default function Page() {
 						>
 							<a
 								href="https://pkgs.tailscale.com/stable/tailscale-setup-latest.exe"
-								aria-label="Download for Windows"
+								aria-label={t('onboarding.download_windows')}
 								target="_blank"
 								rel="noreferrer"
 							>
 								<Button variant="heavy" className="my-4 w-full">
-									Download for Windows
+									{t('onboarding.download_windows')}
 								</Button>
 							</a>
 							<p className="text-sm text-headplane-600 dark:text-headplane-300 text-center">
@@ -207,12 +208,12 @@ export default function Page() {
 						>
 							<a
 								href="https://pkgs.tailscale.com/stable/Tailscale-latest-macos.pkg"
-								aria-label="Download for macOS"
+								aria-label={t('onboarding.download_macos')}
 								target="_blank"
 								rel="noreferrer"
 							>
 								<Button variant="heavy" className="my-4 w-full">
-									Download for macOS
+									{t('onboarding.download_macos')}
 								</Button>
 							</a>
 							<p className="text-sm text-headplane-600 dark:text-headplane-300 text-center">
@@ -239,12 +240,12 @@ export default function Page() {
 						>
 							<a
 								href="https://apps.apple.com/us/app/tailscale/id1470499037"
-								aria-label="Download for iOS"
+								aria-label={t('onboarding.download_ios')}
 								target="_blank"
 								rel="noreferrer"
 							>
 								<Button variant="heavy" className="my-4 w-full">
-									Download for iOS
+									{t('onboarding.download_ios')}
 								</Button>
 							</a>
 							<p className="text-sm text-headplane-600 dark:text-headplane-300 text-center">
@@ -262,12 +263,12 @@ export default function Page() {
 						>
 							<a
 								href="https://play.google.com/store/apps/details?id=com.tailscale.ipn"
-								aria-label="Download for Android"
+								aria-label={t('onboarding.download_android')}
 								target="_blank"
 								rel="noreferrer"
 							>
 								<Button variant="heavy" className="my-4 w-full">
-									Download for Android
+									{t('onboarding.download_android')}
 								</Button>
 							</a>
 							<p className="text-sm text-headplane-600 dark:text-headplane-300 text-center">

--- a/app/routes/users/overview.tsx
+++ b/app/routes/users/overview.tsx
@@ -5,6 +5,7 @@ import type { LoadContext } from '~/server';
 import { Capabilities } from '~/server/web/roles';
 import { Machine, User } from '~/types';
 import cn from '~/utils/cn';
+import { t } from '~/utils/i18n';
 import ManageBanner from './components/manage-banner';
 import UserRow from './components/user-row';
 import { userAction } from './user-actions';
@@ -103,7 +104,7 @@ export default function Page() {
 
 	return (
 		<>
-			<h1 className="text-2xl font-medium mb-1.5">Users</h1>
+			<h1 className="text-2xl font-medium mb-1.5">{t('users.title')}</h1>
 			<p className="mb-8 text-md">
 				Manage the users in your network and their permissions. Tip: You can
 				drag machines between users to change ownership.

--- a/app/utils/i18n.ts
+++ b/app/utils/i18n.ts
@@ -1,0 +1,15 @@
+import en from '../../locales/en/translation.json';
+
+function getNested(obj: Record<string, unknown>, path: string[]): unknown {
+	return path.reduce<unknown>((acc, key) => {
+		if (acc && typeof acc === 'object') {
+			return (acc as Record<string, unknown>)[key];
+		}
+		return undefined;
+	}, obj);
+}
+
+export function t(key: string): string {
+	const result = getNested(en as Record<string, unknown>, key.split('.'));
+	return typeof result === 'string' ? result : key;
+}

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,0 +1,31 @@
+{
+	"header": {
+		"download": "Download",
+		"nav": {
+			"machines": "Machines",
+			"users": "Users"
+		}
+	},
+	"machines": {
+		"all_machines": "All Machines",
+		"title": "Machines",
+		"tooltip_short_domain": "Users of your tailnet can use this DNS short name to access this machine.",
+		"tooltip_full_domain": "Users of your tailnet can use this DNS name to access this machine."
+	},
+	"onboarding": {
+		"download_selector": "Download Selector",
+		"download_windows": "Download for Windows",
+		"download_macos": "Download for macOS",
+		"download_ios": "Download for iOS",
+		"download_android": "Download for Android"
+	},
+	"users": {
+		"title": "Users",
+		"delete_has_machines": "Users cannot be deleted if they have machines. Please delete or re-assign their machines to other users before proceeding.",
+		"manage_banner": {
+			"oidc_prefix": "Users are managed through your ",
+			"oidc_suffix": ". Groups and user information do not automatically sync. ",
+			"not_managed": "Users are not managed externally. Using OpenID Connect can create a better experience when using Headscale. "
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add simple translation utility and English catalog
- replace hardcoded "Download", "Machines", and "Users" strings with `t` calls across header, onboarding, and machine/user pages

## Testing
- `pnpm biome check --write app/components/Header.tsx app/routes/machines/machine.tsx app/routes/machines/overview.tsx app/routes/users/components/manage-banner.tsx app/routes/users/dialogs/delete-user.tsx app/routes/users/onboarding.tsx app/routes/users/overview.tsx app/utils/i18n.ts locales/en/translation.json`
- `pnpm typecheck` *(fails: Property 'displayName' does not exist on type..., Cannot find module '~/utils/sessions.server', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e8d9aae88325a5d26767f9d01da4